### PR TITLE
Removing MYSQL_USER from the docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,6 @@ services:
         command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
         restart: always # always restart unless stopped manually
         environment:
-            MYSQL_USER: root
             MYSQL_ROOT_PASSWORD: secret
             MYSQL_PASSWORD: secret
         networks:


### PR DESCRIPTION
MySQL root user is created automatically with MySQL docker image and this line will only cause an error when starting the container

Because of that, the container will keep restarting and never be healthy